### PR TITLE
fix: template score is wrong when the p-value is zero

### DIFF
--- a/digenome/src/main/scala/com/editasmedicine/digenome/IdentifyCutSites.scala
+++ b/digenome/src/main/scala/com/editasmedicine/digenome/IdentifyCutSites.scala
@@ -322,8 +322,9 @@ object IdentifyCutSites {
     /** Turn a putative p-value into a score, accounting for the fact that the p-value may have underflowed. */
     private def score(pvalue: Double): Double = {
       require(pvalue >= 0 && pvalue <= 1, s"pvalue $pvalue is not in range 0-1.")
-      if (pvalue == 0) math.ceil(-log10(Double.MinPositiveValue))
-      else -log10(pvalue)
+      // Protect against pvalue=0 which would yield score=Inf
+      val nonZeroP = math.max(pvalue, Double.MinPositiveValue)
+      -log10(pvalue)
     }
 
     /** Given an array of counts, gives the index of the median. */

--- a/digenome/src/main/scala/com/editasmedicine/digenome/IdentifyCutSites.scala
+++ b/digenome/src/main/scala/com/editasmedicine/digenome/IdentifyCutSites.scala
@@ -322,7 +322,7 @@ object IdentifyCutSites {
     /** Turn a putative p-value into a score, accounting for the fact that the p-value may have underflowed. */
     private def score(pvalue: Double): Double = {
       require(pvalue >= 0 && pvalue <= 1, s"pvalue $pvalue is not in range 0-1.")
-      if (pvalue == 0) math.floor(-log10(Double.MinPositiveValue))
+      if (pvalue == 0) math.ceil(-log10(Double.MinPositiveValue))
       else -log10(pvalue)
     }
 

--- a/digenome/src/main/scala/com/editasmedicine/digenome/IdentifyCutSites.scala
+++ b/digenome/src/main/scala/com/editasmedicine/digenome/IdentifyCutSites.scala
@@ -322,7 +322,7 @@ object IdentifyCutSites {
     /** Turn a putative p-value into a score, accounting for the fact that the p-value may have underflowed. */
     private def score(pvalue: Double): Double = {
       require(pvalue >= 0 && pvalue <= 1, s"pvalue $pvalue is not in range 0-1.")
-      if (pvalue == 0) - math.floor(-log10(Double.MinPositiveValue))
+      if (pvalue == 0) math.floor(-log10(Double.MinPositiveValue))
       else -log10(pvalue)
     }
 


### PR DESCRIPTION
@tfenne

The effect is that a really _significant_ putative cut site (that has a p-value of zero) will end up with a really poor (insignificant score).  This occurs only when we have very high-coverage at such a cut site.

